### PR TITLE
removed byref arg on call to WinClipAPI.memcopy

### DIFF
--- a/WinClip.ahk
+++ b/WinClip.ahk
@@ -34,12 +34,12 @@ class WinClip extends WinClip_base
                                 ,CF_TIFF : 6 ;Tagged-image file format.
                                 ,CF_UNICODETEXT : 13 ;Unicode text format. Each line ends with a carriage return/linefeed (CR-LF) combination. A null character signals the end of the data.
                                 ,CF_WAVE : 12 } ;Represents audio data in one of the standard wave formats, such as 11 kHz or 22 kHz PCM.
-    
+
                            WM_COPY := 0x301
                                 ,WM_CLEAR := 0x0303
                                 ,WM_CUT := 0x0300
                                 ,WM_PASTE := 0x0302
-    
+
     skipFormats := {      2      : 0 ;"CF_BITMAP"
                                 ,17     : 0 ;"CF_DIBV5"
                                 ,0x0082 : 0 ;"CF_DSPBITMAP"
@@ -50,7 +50,7 @@ class WinClip extends WinClip_base
                                 ,3      : 0 ;"CF_METAFILEPICT"
                                 ,7      : 0 ;"CF_OEMTEXT"
                                 ,1      : 0 } ;"CF_TEXT"
-                                                            
+
     formatByValue := {    2 : "CF_BITMAP"
                                 ,8 : "CF_DIB"
                                 ,17 : "CF_DIBV5"
@@ -77,13 +77,13 @@ class WinClip extends WinClip_base
                                 ,6 : "CF_TIFF"
                                 ,13 : "CF_UNICODETEXT"
                                 ,12 : "CF_WAVE" }
-    
+
     __New()
     {
         this.isinstance := 1
         this.allData := ""
     }
- 
+
     _toclipboard( &data, size )
     {
         if !WinClipAPI.OpenClipboard()
@@ -123,7 +123,7 @@ class WinClip extends WinClip_base
         WinClipAPI.CloseClipboard()
         return lastPartOffset
     }
-    
+
     _fromclipboard( &clipData )
     {
         if !WinClipAPI.OpenClipboard()
@@ -180,7 +180,7 @@ class WinClip extends WinClip_base
         WinClipAPI.CloseClipboard()
         return structSize
     }
-    
+
     _IsInstance( funcName )
     {
         if !this.isinstance
@@ -190,7 +190,7 @@ class WinClip extends WinClip_base
         }
         return 1
     }
-    
+
     _loadFile( filePath, &Data )
     {
         f := FileOpen( filePath, "r","UTF-8" )
@@ -223,7 +223,7 @@ class WinClip extends WinClip_base
         WinClipAPI.memcopy( this.allData.ptr, data.ptr, size )
         return size
     }
-    
+
     _getClipData( &data )
     {
         ; if !( clipSize := ObjGetCapacity( this, "allData" ) )
@@ -233,17 +233,17 @@ class WinClip extends WinClip_base
         If (Type(this.allData) != "Buffer")
             return 0
         data := Buffer( this.allData.size, 0 )
-        WinClipAPI.memcopy( &data, this.allData.ptr, this.allData.size )
+        WinClipAPI.memcopy( data, this.allData.ptr, this.allData.size )
         return this.allData.size
     }
-    
+
     __Delete()
     {
         ; ObjSetCapacity( this, "allData", 0 )
         this.allData := ""
         return
     }
-    
+
     _parseClipboardData( &data, size )
     {
         offset := 0
@@ -261,14 +261,14 @@ class WinClip extends WinClip_base
             params := { name : this._getFormatName( fmt ), size : dataSize, buffer : Buffer(dataSize) }
             ; ObjSetCapacity( params, "buffer", dataSize )
             ; pBuf := ObjGetAddress( params, "buffer" )
-            
+
             WinClipAPI.memcopy( params.buffer.ptr, data.ptr + offset, dataSize )
             formats[ fmt ] := params
             offset += dataSize
         }
         return formats
     }
-    
+
     _compileClipData( &out_data, objClip )
     {
         if !IsObject( objClip )
@@ -290,14 +290,14 @@ class WinClip extends WinClip_base
         }
         return clipSize
     }
-    
+
     GetFormats()
     {
         if !( clipSize := this._fromclipboard( &clipData ) )
             return 0
         return this._parseClipboardData( &clipData, clipSize )
     }
-    
+
     iGetFormats()
     {
         this._IsInstance( A_ThisFunc )
@@ -305,12 +305,12 @@ class WinClip extends WinClip_base
             return 0
         return this._parseClipboardData( &clipData, clipSize )
     }
-    
+
     Snap( &data )
     {
         return this._fromclipboard( &data )
     }
-    
+
     iSnap()
     {
         this._IsInstance( A_ThisFunc )
@@ -339,7 +339,7 @@ class WinClip extends WinClip_base
             return 0
         return this._saveFile( filePath, &data, size )
     }
-    
+
     iSave( filePath )
     {
         this._IsInstance( A_ThisFunc )
@@ -371,14 +371,14 @@ class WinClip extends WinClip_base
         WinClipAPI.CloseClipboard()
         return 1
     }
-    
+
     iClear()
     {
         this._IsInstance( A_ThisFunc )
         ; ObjSetCapacity( this, "allData", 0 )
         this.allData := ""
     }
-    
+
     Copy( timeout := 1, method := 1 )
     {
         this.Snap( &data )
@@ -392,7 +392,7 @@ class WinClip extends WinClip_base
             this.Restore( &data )
         return !ret
     }
-    
+
     iCopy( timeout := 1, method := 1 )
     {
         this._IsInstance( A_ThisFunc )
@@ -412,7 +412,7 @@ class WinClip extends WinClip_base
         this.Restore( &data )
         return bytesCopied
     }
-    
+
     Paste( plainText := "", method := 1 )
     {
         ret := 0
@@ -435,7 +435,7 @@ class WinClip extends WinClip_base
             ret := !this._isClipEmpty()
         return ret
     }
-    
+
     iPaste( method := 1 )
     {
         this._IsInstance( A_ThisFunc )
@@ -450,22 +450,22 @@ class WinClip extends WinClip_base
         this.Restore( &data )
         return bytesRestored
     }
-    
+
     IsEmpty()
     {
         return this._isClipEmpty()
     }
-    
+
     iIsEmpty()
     {
         return !this.iGetSize()
     }
-    
+
     _isClipEmpty()
     {
         return !WinClipAPI.CountClipboardFormats()
     }
-    
+
     _waitClipReady( timeout := 10000 )
     {
         start_time := A_TickCount
@@ -484,7 +484,7 @@ class WinClip extends WinClip_base
             return 0
         return this._setClipData( &clipData, clipSize )
     }
-    
+
     SetText( textData )
     {
         if ( textData = "" )
@@ -503,7 +503,7 @@ class WinClip extends WinClip_base
             return ""
         return strget( &out_data, out_size, "UTF-8" )
     }
-    
+
     iGetRTF()
     {
         this._IsInstance( A_ThisFunc )
@@ -513,7 +513,7 @@ class WinClip extends WinClip_base
             return ""
         return strget( &out_data, out_size, "UTF-8" )
     }
-    
+
     SetRTF( textData )
     {
         if ( textData = "" )
@@ -523,7 +523,7 @@ class WinClip extends WinClip_base
                     return 0
         return this._toclipboard( clipData, clipSize )
     }
-    
+
     iSetRTF( textData )
     {
         if ( textData = "" )
@@ -557,7 +557,7 @@ class WinClip extends WinClip_base
             return 0
         return this._setClipData( &clipData, clipSize )
     }
-    
+
     AppendText( textData )
     {
         if ( textData = "" )
@@ -630,7 +630,7 @@ class WinClip extends WinClip_base
         objFormats[ uFmt ].size := sLen
         return this._compileClipData( &clipData, objFormats )
     }
-    
+
     _appendText( &clipData, clipSize, textData, _IsSet := 0 )
     {
         objFormats := this._parseClipboardData( &clipData, clipSize )
@@ -647,7 +647,7 @@ class WinClip extends WinClip_base
         objFormats[ uFmt ].size := sz
         return this._compileClipData( &clipData, objFormats )
     }
-    
+
     _getFiles( pDROPFILES )
     {
         fWide := numget( pDROPFILES, 16, "uchar" ) ;getting fWide value from DROPFILES struct
@@ -661,7 +661,7 @@ class WinClip extends WinClip_base
         }
         return list
     }
-    
+
     _setFiles( &clipData, clipSize, files, append := 0, isCut := 0 )
     {
         objFormats := this._parseClipboardData( &clipData, clipSize )
@@ -695,7 +695,7 @@ class WinClip extends WinClip_base
         NumPut( "UInt", isCut ? 2 : 5, objFormats[ prefFmt ].buffer.ptr, 0 )
         return this._compileClipData( &clipData, objFormats )
     }
-    
+
     SetFiles( files, isCut := 0 )
     {
         if ( files = "" )
@@ -705,7 +705,7 @@ class WinClip extends WinClip_base
             return 0
         return this._toclipboard( &clipData, clipSize )
     }
-    
+
     iSetFiles( files, isCut := 0 )
     {
         this._IsInstance( A_ThisFunc )
@@ -716,7 +716,7 @@ class WinClip extends WinClip_base
             return 0
         return this._setClipData( &clipData, clipSize )
     }
-    
+
     AppendFiles( files, isCut := 0 )
     {
         if ( files = "" )
@@ -726,7 +726,7 @@ class WinClip extends WinClip_base
             return 0
         return this._toclipboard( clipData, clipSize )
     }
-    
+
     iAppendFiles( files, isCut := 0 )
     {
         this._IsInstance( A_ThisFunc )
@@ -737,7 +737,7 @@ class WinClip extends WinClip_base
             return 0
         return this._setClipData( &clipData, clipSize )
     }
-    
+
     GetFiles()
     {
         if !( clipSize := this._fromclipboard( &clipData ) )
@@ -746,7 +746,7 @@ class WinClip extends WinClip_base
             return ""
         return this._getFiles( out_data )
     }
-    
+
     iGetFiles()
     {
         this._IsInstance( A_ThisFunc )
@@ -756,7 +756,7 @@ class WinClip extends WinClip_base
             return ""
         return this._getFiles( out_data )
     }
-    
+
     _getFormatData( &out_data, &data, size, needleFormat )
     {
         needleFormat := (WinClipAPI.IsInteger( needleFormat ) ? needleFormat : WinClipAPI.RegisterClipboardFormat( needleFormat ))
@@ -781,7 +781,7 @@ class WinClip extends WinClip_base
         }
         return 0
     }
-    
+
     _DIBtoHBITMAP( &dibData )
     {
         ;http://ebersys.blogspot.com/2009/06/how-to-convert-dib-to-bitmap.html
@@ -793,7 +793,7 @@ class WinClip extends WinClip_base
         WinClipAPI.Gdip_Shutdown( gdip_token )
         return hBitmap
     }
-    
+
     GetBitmap()
     {
         if !( clipSize := this._fromclipboard( &clipData ) )
@@ -802,7 +802,7 @@ class WinClip extends WinClip_base
             return ""
         return this._DIBtoHBITMAP( &out_data )
     }
-    
+
     iGetBitmap()
     {
         this._IsInstance( A_ThisFunc )
@@ -812,7 +812,7 @@ class WinClip extends WinClip_base
             return ""
         return this._DIBtoHBITMAP( &out_data )
     }
-    
+
     _BITMAPtoDIB( bitmap, &DIB )
     {
         A_ThisLabel := ""
@@ -842,7 +842,7 @@ class WinClip extends WinClip_base
         DllCall( "GetObject", "Ptr", hBitmap, "Uint", size, "ptr", bm.ptr )
         biBitCount := NumGet( bm, 16, "UShort" )*NumGet( bm, 18, "UShort" )
         nColors := (1 << biBitCount)
-    if ( nColors > 256 ) 
+    if ( nColors > 256 )
         nColors := 0
     bmiLen  := 40 + nColors * 4
         bmi := Buffer( bmiLen, 0 )
@@ -854,14 +854,14 @@ class WinClip extends WinClip_base
         NumPut( "UShort", biBitCount, bmi, 14 )
         NumPut( "UInt", 0, bmi, 16 ) ;compression must be BI_RGB
 
-        ; Get BITMAPINFO. 
+        ; Get BITMAPINFO.
         if !DllCall("GetDIBits"
                             ,"ptr",hdc
                             ,"ptr",hBitmap
-                            ,"uint",0 
+                            ,"uint",0
                             ,"uint",biHeight
-                            ,"ptr",0      ;lpvBits 
-                            ,"uptr",bmi.ptr  ;lpbi 
+                            ,"ptr",0      ;lpvBits
+                            ,"uptr",bmi.ptr  ;lpbi
                             ,"uint",0)    ;DIB_RGB_COLORS
             goto _BITMAPtoDIB_cleanup
         biSizeImage := NumGet( bmi, 20, "UInt" )
@@ -882,10 +882,10 @@ class WinClip extends WinClip_base
         if !DllCall("GetDIBits"
                             ,"ptr",hdc
                             ,"ptr",hBitmap
-                            ,"uint",0 
+                            ,"uint",0
                             ,"uint",biHeight
-                            ,"ptr",DIB.ptr + bmiLen     ;lpvBits 
-                            ,"ptr",DIB.ptr  ;lpbi 
+                            ,"ptr",DIB.ptr + bmiLen     ;lpvBits
+                            ,"ptr",DIB.ptr  ;lpbi
                             ,"uint",0) {    ;DIB_RGB_COLORS
             A_ThisLabel := "_BITMAPtoDIB_cleanup"
             goto _BITMAPtoDIB_cleanup
@@ -900,7 +900,7 @@ _BITMAPtoDIB_cleanup:
             return 0
         return DIBLen
     }
-    
+
     _setBitmap( &DIB, DIBSize, &clipData, clipSize )
     {
         objFormats := this._parseClipboardData( &clipData, clipSize )
@@ -910,7 +910,7 @@ _BITMAPtoDIB_cleanup:
         WinClipAPI.memcopy( objFormats[ uFmt ].buffer.ptr, DIB.ptr, DIBSize )
         return this._compileClipData( &clipData, objFormats )
     }
-    
+
     SetBitmap( bitmap )
     {
         if ( DIBSize := this._BITMAPtoDIB( bitmap, &DIB ) )
@@ -921,7 +921,7 @@ _BITMAPtoDIB_cleanup:
         }
         return 0
     }
-    
+
     iSetBitmap( bitmap )
     {
         this._IsInstance( A_ThisFunc )
@@ -933,7 +933,7 @@ _BITMAPtoDIB_cleanup:
         }
         return 0
     }
-    
+
     GetText()
     {
         if !( clipSize := this._fromclipboard( &clipData ) )
@@ -952,7 +952,7 @@ _BITMAPtoDIB_cleanup:
             return ""
         return strget( out_data, out_size / 2, "UTF-16" )
     }
-    
+
     GetHtml()
     {
         if !( clipSize := this._fromclipboard( &clipData ) )
@@ -961,7 +961,7 @@ _BITMAPtoDIB_cleanup:
             return ""
         return strget( out_data, out_size, "UTF-8" )
     }
-    
+
     iGetHtml()
     {
         this._IsInstance( A_ThisFunc )
@@ -971,7 +971,7 @@ _BITMAPtoDIB_cleanup:
             return ""
         return strget( out_data, out_size, "UTF-8" )
     }
-    
+
     _getFormatName( iformat )
     {
         if this.formatByValue.HasProp( iformat )
@@ -979,32 +979,32 @@ _BITMAPtoDIB_cleanup:
         else
             return WinClipAPI.GetClipboardFormatName( iformat )
     }
-    
+
     iGetData( &Data )
     {
         this._IsInstance( A_ThisFunc )
         return this._getClipData( Data.ptr )
     }
-    
+
     iSetData( &data )
     {
         this._IsInstance( A_ThisFunc )
         return this._setClipData( data.ptr, data.size )
     }
-    
+
     iGetSize()
     {
         this._IsInstance( A_ThisFunc )
         return this.alldata.size
     }
-    
+
     HasFormat( fmt )
     {
         if !fmt
             return 0
         return WinClipAPI.IsClipboardFormatAvailable( WinClipAPI.IsInteger( fmt ) ? fmt : WinClipAPI.RegisterClipboardFormat( fmt )  )
     }
-    
+
     iHasFormat( fmt )
     {
         this._IsInstance( A_ThisFunc )
@@ -1032,7 +1032,7 @@ _BITMAPtoDIB_cleanup:
         }
         return 0
     }
-    
+
     iSaveBitmap( filePath, format )
     {
         this._IsInstance( A_ThisFunc )
@@ -1051,7 +1051,7 @@ _BITMAPtoDIB_cleanup:
         WinClipAPI.Gdip_Shutdown( gdip_token )
         return 1
     }
-    
+
     SaveBitmap( filePath, format )
     {
         if ( filePath = "" || format = "" )


### PR DESCRIPTION
So I had this `Error: This value of type "VarRef" has no property named "Ptr".`
Removing the `&` seems to have it fixed. :)

Pardon me. VS Code also removed all the trailing whitespace 🙈
Important line is 236! 

cheers:
ëRiC